### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .gradle
+libs/
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
 .kotlin
+*.jar
 
 ### IntelliJ IDEA ###
 .idea/modules.xml


### PR DESCRIPTION
You should not put compiled .jar files in your git repository (with the exception of gradle wrapper jar). Additionally, this repository distributes the server jar in libs/HytaleServer.jar which is against Hytale EULA. Please remove it from commit history.